### PR TITLE
Rename regular text color hover token

### DIFF
--- a/source/components/accordion/accordion.scss
+++ b/source/components/accordion/accordion.scss
@@ -36,7 +36,7 @@
     }
 
     &:hover {
-      color: $color-text-regular-hover;
+      color: $color-text-regular-divergent-hover;
     }
   }
 

--- a/source/components/global-footer/global-footer.scss
+++ b/source/components/global-footer/global-footer.scss
@@ -45,7 +45,7 @@
     }
 
     &:hover {
-      color: $color-text-regular-hover;
+      color: $color-text-regular-divergent-hover;
     }
   }
 

--- a/source/components/global-header/global-header.scss
+++ b/source/components/global-header/global-header.scss
@@ -36,7 +36,7 @@
     }
 
     &:hover {
-      color: $color-text-regular-hover;
+      color: $color-text-regular-divergent-hover;
     }
   }
 
@@ -65,13 +65,13 @@
       }
 
       &:hover {
-        color: $color-text-regular-hover;
+        color: $color-text-regular-divergent-hover;
       }
 
       &.activated {
         padding-bottom: calc(#{$space-small-d} - #{$border-width-thick-a});
         border-bottom: $border-width-thick-a solid $color-border-activated;
-        color: $color-text-regular-hover;
+        color: $color-text-regular-divergent-hover;
       }
     }
   }

--- a/source/components/tabset/tabset.scss
+++ b/source/components/tabset/tabset.scss
@@ -31,7 +31,7 @@
     }
 
     &:hover {
-      color: $color-text-regular-hover;
+      color: $color-text-regular-divergent-hover;
     }
 
     &.activated {

--- a/source/tokens/color.scss
+++ b/source/tokens/color.scss
@@ -4,7 +4,7 @@
 // Text
 
 $color-text-regular: hsl(240, 8%, 28%);
-$color-text-regular-hover: hsl(208, 100%, 36%);
+$color-text-regular-divergent-hover: hsl(208, 100%, 36%);
 
 $color-text-primary: hsl(208, 100%, 36%);
 $color-text-secondary: hsl(240, 8%, 28%);


### PR DESCRIPTION
Some navigational items may employ radically different colors for the default and hover states. Use the "divergent" keyword to designate tokens corresponding to such state colors in order to ensure purposeful changes can be easily made.