### PR TITLE
Add reference color tokens

### DIFF
--- a/source/tokens/color.scss
+++ b/source/tokens/color.scss
@@ -1,95 +1,97 @@
 // COLOR
 // -----------------------------------------------------------------------------
 
+@use "reference/color" as *;
+
 // Text
 
-$color-text-regular: hsl(240, 8%, 28%);
-$color-text-regular-divergent-hover: hsl(208, 100%, 36%);
+$color-text-regular: $color-gray-050;
+$color-text-regular-divergent-hover: $color-blue-100;
 
-$color-text-primary: hsl(208, 100%, 36%);
-$color-text-secondary: hsl(240, 8%, 28%);
+$color-text-primary: $color-blue-100;
+$color-text-secondary: $color-gray-050;
 
-$color-text-positive: hsl(138, 100%, 22%);
-$color-text-attentive: hsl(44, 100%, 24%);
-$color-text-negative: hsl(12, 100%, 36%);
+$color-text-positive: $color-green-100;
+$color-text-attentive: $color-yellow-100;
+$color-text-negative: $color-red-100;
 
-$color-text-inverse: hsl(0, 0%, 100%);
+$color-text-inverse: $color-white;
 
-$color-text-activated: hsl(208, 100%, 36%);
+$color-text-activated: $color-blue-100;
 
 // Border
 
-$color-border-regular: hsl(240, 6%, 56%);
-$color-border-regular-subtle: hsl(240, 4%, 86%);
+$color-border-regular: $color-gray-250;
+$color-border-regular-subtle: $color-gray-700;
 
-$color-border-primary: hsl(208, 76%, 54%);
-$color-border-secondary: hsl(240, 6%, 56%);
+$color-border-primary: $color-blue-250;
+$color-border-secondary: $color-gray-250;
 
-$color-border-positive: hsl(138, 56%, 40%);
-$color-border-attentive: hsl(44, 56%, 42%);
-$color-border-negative: hsl(12, 56%, 58%);
+$color-border-positive: $color-green-250;
+$color-border-attentive: $color-yellow-250;
+$color-border-negative: $color-red-250;
 
-$color-border-inverse: hsl(0, 0%, 100%);
+$color-border-inverse: $color-white;
 
-$color-border-activated: hsl(208, 100%, 36%);
-$color-border-selected: hsl(208, 100%, 36%);
+$color-border-activated: $color-blue-100;
+$color-border-selected: $color-blue-100;
 
 // Background
 
-$color-background-regular: hsl(0, 0%, 100%);
-$color-background-regular-hover: hsl(240, 4%, 96%);
-$color-background-regular-active: hsl(240, 4%, 92%);
+$color-background-regular: $color-white;
+$color-background-regular-hover: $color-gray-900;
+$color-background-regular-active: $color-gray-800;
 
-$color-background-primary: hsl(208, 100%, 36%);
-$color-background-primary-hover: hsl(208, 100%, 32%);
-$color-background-primary-active: hsl(208, 100%, 28%);
-$color-background-primary-subtle: hsl(208, 92%, 96%);
-$color-background-primary-subtle-alt: hsl(208, 92%, 92%);
-$color-background-primary-transparent-hover: hsl(208, 92%, 96%);
-$color-background-primary-transparent-active: hsl(208, 92%, 92%);
-$color-background-secondary: hsl(240, 8%, 28%);
-$color-background-secondary-hover: hsl(240, 8%, 22%);
-$color-background-secondary-active: hsl(240, 8%, 16%);
-$color-background-secondary-subtle: hsl(240, 4%, 96%);
-$color-background-secondary-subtle-alt: hsl(240, 4%, 92%);
-$color-background-secondary-transparent-hover: hsl(240, 4%, 96%);
-$color-background-secondary-transparent-active: hsl(240, 4%, 92%);
+$color-background-primary: $color-blue-100;
+$color-background-primary-hover: $color-blue-075;
+$color-background-primary-active: $color-blue-050;
+$color-background-primary-subtle: $color-blue-900;
+$color-background-primary-subtle-alt: $color-blue-800;
+$color-background-primary-transparent-hover: $color-blue-900;
+$color-background-primary-transparent-active: $color-blue-800;
+$color-background-secondary: $color-gray-050;
+$color-background-secondary-hover: $color-gray-025;
+$color-background-secondary-active: $color-gray-000;
+$color-background-secondary-subtle: $color-gray-900;
+$color-background-secondary-subtle-alt: $color-gray-800;
+$color-background-secondary-transparent-hover: $color-gray-900;
+$color-background-secondary-transparent-active: $color-gray-800;
 
-$color-background-positive: hsl(138, 100%, 22%);
-$color-background-positive-hover: hsl(138, 100%, 20%);
-$color-background-positive-active: hsl(138, 100%, 16%);
-$color-background-positive-subtle: hsl(138, 76%, 94%);
-$color-background-positive-subtle-alt: hsl(138, 76%, 86%);
-$color-background-positive-transparent-hover: hsl(138, 76%, 94%);
-$color-background-positive-transparent-active: hsl(138, 76%, 86%);
-$color-background-attentive: hsl(44, 100%, 24%);
-$color-background-attentive-hover: hsl(44, 100%, 22%);
-$color-background-attentive-active: hsl(44, 100%, 18%);
-$color-background-attentive-subtle: hsl(44, 80%, 94%);
-$color-background-attentive-subtle-alt: hsl(44, 80%, 86%);
-$color-background-attentive-transparent-hover: hsl(44, 80%, 94%);
-$color-background-attentive-transparent-active: hsl(44, 80%, 86%);
-$color-background-negative: hsl(12, 100%, 36%);
-$color-background-negative-hover: hsl(12, 100%, 32%);
-$color-background-negative-active: hsl(12, 100%, 28%);
-$color-background-negative-subtle: hsl(12, 52%, 96%);
-$color-background-negative-subtle-alt: hsl(12, 52%, 92%);
-$color-background-negative-transparent-hover: hsl(12, 52%, 96%);
-$color-background-negative-transparent-active: hsl(12, 52%, 92%);
+$color-background-positive: $color-green-100;
+$color-background-positive-hover: $color-green-075;
+$color-background-positive-active: $color-green-050;
+$color-background-positive-subtle: $color-green-900;
+$color-background-positive-subtle-alt: $color-green-800;
+$color-background-positive-transparent-hover: $color-green-900;
+$color-background-positive-transparent-active: $color-green-800;
+$color-background-attentive: $color-yellow-100;
+$color-background-attentive-hover: $color-yellow-075;
+$color-background-attentive-active: $color-yellow-050;
+$color-background-attentive-subtle: $color-yellow-900;
+$color-background-attentive-subtle-alt: $color-yellow-800;
+$color-background-attentive-transparent-hover: $color-yellow-900;
+$color-background-attentive-transparent-active: $color-yellow-800;
+$color-background-negative: $color-red-100;
+$color-background-negative-hover: $color-red-075;
+$color-background-negative-active: $color-red-050;
+$color-background-negative-subtle: $color-red-900;
+$color-background-negative-subtle-alt: $color-red-800;
+$color-background-negative-transparent-hover: $color-red-900;
+$color-background-negative-transparent-active: $color-red-800;
 
-$color-background-inverse: hsl(0, 0%, 100%);
-$color-background-inverse-hover: hsl(0, 0%, 100%, 0.92);
-$color-background-inverse-active: hsl(0, 0%, 100%, 0.84);
-$color-background-inverse-transparent-hover: hsl(0, 0%, 100%, 0.08);
-$color-background-inverse-transparent-active: hsl(0, 0%, 100%, 0.16);
+$color-background-inverse: $color-white;
+$color-background-inverse-hover: $color-white-transparent-900;
+$color-background-inverse-active: $color-white-transparent-825;
+$color-background-inverse-transparent-hover: $color-white-transparent-075;
+$color-background-inverse-transparent-active: $color-white-transparent-150;
 
-$color-background-transparent: hsl(0, 0%, 0%, 0);
-$color-background-transparent-dim: hsl(0, 0%, 0%, 0.72);
+$color-background-transparent: $color-transparent;
+$color-background-transparent-dim: $color-black-transparent-700;
 
-$color-background-selected: hsl(208, 100%, 36%);
+$color-background-selected: $color-blue-100;
 
 // Outline
 
-$color-outline-focus: hsl(208, 100%, 36%);
+$color-outline-focus: $color-blue-100;
 
-$color-outline-inverse-focus: hsl(0, 0%, 100%);
+$color-outline-inverse-focus: $color-white;

--- a/source/tokens/reference/color.scss
+++ b/source/tokens/reference/color.scss
@@ -1,0 +1,64 @@
+// COLOR
+// -----------------------------------------------------------------------------
+
+// White
+
+$color-white: hsl(0, 0%, 100%);
+$color-white-transparent-075: hsl(0, 0%, 100%, 0.08);
+$color-white-transparent-150: hsl(0, 0%, 100%, 0.16);
+$color-white-transparent-825: hsl(0, 0%, 100%, 0.84);
+$color-white-transparent-900: hsl(0, 0%, 100%, 0.92);
+
+// Gray
+
+$color-gray-000: hsl(240, 8%, 16%);
+$color-gray-025: hsl(240, 8%, 22%);
+$color-gray-050: hsl(240, 8%, 28%);
+$color-gray-250: hsl(240, 6%, 56%);
+$color-gray-700: hsl(240, 4%, 86%);
+$color-gray-800: hsl(240, 4%, 92%);
+$color-gray-900: hsl(240, 4%, 96%);
+
+// Black
+
+$color-black-transparent-700: hsl(0, 0%, 0%, 0.72);
+
+// Red
+
+$color-red-050: hsl(12, 100%, 28%);
+$color-red-075: hsl(12, 100%, 32%);
+$color-red-100: hsl(12, 100%, 36%);
+$color-red-250: hsl(12, 56%, 58%);
+$color-red-800: hsl(12, 52%, 92%);
+$color-red-900: hsl(12, 52%, 96%);
+
+// Yellow
+
+$color-yellow-050: hsl(44, 100%, 18%);
+$color-yellow-075: hsl(44, 100%, 22%);
+$color-yellow-100: hsl(44, 100%, 24%);
+$color-yellow-250: hsl(44, 56%, 42%);
+$color-yellow-800: hsl(44, 80%, 86%);
+$color-yellow-900: hsl(44, 80%, 94%);
+
+// Green
+
+$color-green-050: hsl(138, 100%, 16%);
+$color-green-075: hsl(138, 100%, 20%);
+$color-green-100: hsl(138, 100%, 22%);
+$color-green-250: hsl(138, 56%, 40%);
+$color-green-800: hsl(138, 76%, 86%);
+$color-green-900: hsl(138, 76%, 94%);
+
+// Blue
+
+$color-blue-050: hsl(208, 100%, 28%);
+$color-blue-075: hsl(208, 100%, 32%);
+$color-blue-100: hsl(208, 100%, 36%);
+$color-blue-250: hsl(208, 76%, 54%);
+$color-blue-800: hsl(208, 92%, 92%);
+$color-blue-900: hsl(208, 92%, 96%);
+
+// Transparent
+
+$color-transparent: hsl(0, 0%, 0%, 0);


### PR DESCRIPTION
Different semantic tokens may employ identical values: the same blue may be used to style primary text, borders on activated items, and primary backgrounds. In order to simplify definitions and ensure consistency, another abstraction layer needs to be added, in the form of reference tokens. These establish all available style values within a design system, thus providing a single source of truth for any design decision.