### PR TITLE
Change low luminance tokens naming convention

### DIFF
--- a/source/tokens/color.scss
+++ b/source/tokens/color.scss
@@ -51,7 +51,7 @@ $color-background-primary-transparent-hover: $color-blue-900;
 $color-background-primary-transparent-active: $color-blue-800;
 $color-background-secondary: $color-gray-050;
 $color-background-secondary-hover: $color-gray-025;
-$color-background-secondary-active: $color-gray-000;
+$color-background-secondary-active: $color-gray-005;
 $color-background-secondary-subtle: $color-gray-900;
 $color-background-secondary-subtle-alt: $color-gray-800;
 $color-background-secondary-transparent-hover: $color-gray-900;

--- a/source/tokens/reference/color.scss
+++ b/source/tokens/reference/color.scss
@@ -11,7 +11,7 @@ $color-white-transparent-900: hsl(0, 0%, 100%, 0.92);
 
 // Gray
 
-$color-gray-000: hsl(0, 0%, 16%);
+$color-gray-005: hsl(0, 0%, 16%);
 $color-gray-025: hsl(0, 0%, 22%);
 $color-gray-050: hsl(0, 0%, 28%);
 $color-gray-250: hsl(0, 0%, 56%);


### PR DESCRIPTION
Color grades are an approximation of color luminance. Using "000" might lead to misunderstandings or incorrect definitions as it implies absolute black is being designated. Instead, use "005" to define colors that have very low luminance.