### PR TITLE
Revise color grading naming conventions

### DIFF
--- a/source/tokens/color.scss
+++ b/source/tokens/color.scss
@@ -5,93 +5,93 @@
 
 // Text
 
-$color-text-regular: $color-gray-050;
-$color-text-regular-divergent-hover: $color-blue-100;
+$color-text-regular: $color-gray-80;
+$color-text-regular-divergent-hover: $color-blue-70;
 
-$color-text-primary: $color-blue-100;
-$color-text-secondary: $color-gray-050;
+$color-text-primary: $color-blue-70;
+$color-text-secondary: $color-gray-80;
 
-$color-text-positive: $color-green-100;
-$color-text-attentive: $color-yellow-100;
-$color-text-negative: $color-red-100;
+$color-text-positive: $color-green-70;
+$color-text-attentive: $color-yellow-70;
+$color-text-negative: $color-red-70;
 
 $color-text-inverse: $color-white;
 
-$color-text-activated: $color-blue-100;
+$color-text-activated: $color-blue-70;
 
 // Border
 
-$color-border-regular: $color-gray-250;
-$color-border-regular-subtle: $color-gray-700;
+$color-border-regular: $color-gray-50;
+$color-border-regular-subtle: $color-gray-15;
 
-$color-border-primary: $color-blue-250;
-$color-border-secondary: $color-gray-250;
+$color-border-primary: $color-blue-50;
+$color-border-secondary: $color-gray-50;
 
-$color-border-positive: $color-green-250;
-$color-border-attentive: $color-yellow-250;
-$color-border-negative: $color-red-250;
+$color-border-positive: $color-green-50;
+$color-border-attentive: $color-yellow-50;
+$color-border-negative: $color-red-50;
 
 $color-border-inverse: $color-white;
 
-$color-border-activated: $color-blue-100;
-$color-border-selected: $color-blue-100;
+$color-border-activated: $color-blue-70;
+$color-border-selected: $color-blue-70;
 
 // Background
 
 $color-background-regular: $color-white;
-$color-background-regular-hover: $color-gray-900;
-$color-background-regular-active: $color-gray-800;
+$color-background-regular-hover: $color-gray-5;
+$color-background-regular-active: $color-gray-10;
 
-$color-background-primary: $color-blue-100;
-$color-background-primary-hover: $color-blue-075;
-$color-background-primary-active: $color-blue-050;
-$color-background-primary-subtle: $color-blue-900;
-$color-background-primary-subtle-alt: $color-blue-800;
-$color-background-primary-transparent-hover: $color-blue-900;
-$color-background-primary-transparent-active: $color-blue-800;
-$color-background-secondary: $color-gray-050;
-$color-background-secondary-hover: $color-gray-025;
-$color-background-secondary-active: $color-gray-005;
-$color-background-secondary-subtle: $color-gray-900;
-$color-background-secondary-subtle-alt: $color-gray-800;
-$color-background-secondary-transparent-hover: $color-gray-900;
-$color-background-secondary-transparent-active: $color-gray-800;
+$color-background-primary: $color-blue-70;
+$color-background-primary-hover: $color-blue-75;
+$color-background-primary-active: $color-blue-80;
+$color-background-primary-subtle: $color-blue-5;
+$color-background-primary-subtle-alt: $color-blue-10;
+$color-background-primary-transparent-hover: $color-blue-5;
+$color-background-primary-transparent-active: $color-blue-10;
+$color-background-secondary: $color-gray-80;
+$color-background-secondary-hover: $color-gray-85;
+$color-background-secondary-active: $color-gray-90;
+$color-background-secondary-subtle: $color-gray-5;
+$color-background-secondary-subtle-alt: $color-gray-10;
+$color-background-secondary-transparent-hover: $color-gray-5;
+$color-background-secondary-transparent-active: $color-gray-10;
 
-$color-background-positive: $color-green-100;
-$color-background-positive-hover: $color-green-075;
-$color-background-positive-active: $color-green-050;
-$color-background-positive-subtle: $color-green-900;
-$color-background-positive-subtle-alt: $color-green-800;
-$color-background-positive-transparent-hover: $color-green-900;
-$color-background-positive-transparent-active: $color-green-800;
-$color-background-attentive: $color-yellow-100;
-$color-background-attentive-hover: $color-yellow-075;
-$color-background-attentive-active: $color-yellow-050;
-$color-background-attentive-subtle: $color-yellow-900;
-$color-background-attentive-subtle-alt: $color-yellow-800;
-$color-background-attentive-transparent-hover: $color-yellow-900;
-$color-background-attentive-transparent-active: $color-yellow-800;
-$color-background-negative: $color-red-100;
-$color-background-negative-hover: $color-red-075;
-$color-background-negative-active: $color-red-050;
-$color-background-negative-subtle: $color-red-900;
-$color-background-negative-subtle-alt: $color-red-800;
-$color-background-negative-transparent-hover: $color-red-900;
-$color-background-negative-transparent-active: $color-red-800;
+$color-background-positive: $color-green-70;
+$color-background-positive-hover: $color-green-75;
+$color-background-positive-active: $color-green-80;
+$color-background-positive-subtle: $color-green-5;
+$color-background-positive-subtle-alt: $color-green-10;
+$color-background-positive-transparent-hover: $color-green-5;
+$color-background-positive-transparent-active: $color-green-10;
+$color-background-attentive: $color-yellow-70;
+$color-background-attentive-hover: $color-yellow-75;
+$color-background-attentive-active: $color-yellow-80;
+$color-background-attentive-subtle: $color-yellow-5;
+$color-background-attentive-subtle-alt: $color-yellow-10;
+$color-background-attentive-transparent-hover: $color-yellow-5;
+$color-background-attentive-transparent-active: $color-yellow-10;
+$color-background-negative: $color-red-70;
+$color-background-negative-hover: $color-red-75;
+$color-background-negative-active: $color-red-80;
+$color-background-negative-subtle: $color-red-5;
+$color-background-negative-subtle-alt: $color-red-10;
+$color-background-negative-transparent-hover: $color-red-5;
+$color-background-negative-transparent-active: $color-red-10;
 
 $color-background-inverse: $color-white;
-$color-background-inverse-hover: $color-white-transparent-900;
-$color-background-inverse-active: $color-white-transparent-825;
-$color-background-inverse-transparent-hover: $color-white-transparent-075;
-$color-background-inverse-transparent-active: $color-white-transparent-150;
+$color-background-inverse-hover: $color-white-transparent-10;
+$color-background-inverse-active: $color-white-transparent-20;
+$color-background-inverse-transparent-hover: $color-white-transparent-90;
+$color-background-inverse-transparent-active: $color-white-transparent-80;
 
 $color-background-transparent: $color-transparent;
-$color-background-transparent-dim: $color-black-transparent-700;
+$color-background-transparent-dim: $color-black-transparent-70;
 
-$color-background-selected: $color-blue-100;
+$color-background-selected: $color-blue-70;
 
 // Outline
 
-$color-outline-focus: $color-blue-100;
+$color-outline-focus: $color-blue-70;
 
 $color-outline-inverse-focus: $color-white;

--- a/source/tokens/reference/color.scss
+++ b/source/tokens/reference/color.scss
@@ -4,60 +4,60 @@
 // White
 
 $color-white: hsl(0, 0%, 100%);
-$color-white-transparent-075: hsl(0, 0%, 100%, 0.08);
-$color-white-transparent-150: hsl(0, 0%, 100%, 0.16);
-$color-white-transparent-825: hsl(0, 0%, 100%, 0.84);
-$color-white-transparent-900: hsl(0, 0%, 100%, 0.92);
+$color-white-transparent-90: hsl(0, 0%, 100%, 0.08);
+$color-white-transparent-80: hsl(0, 0%, 100%, 0.16);
+$color-white-transparent-20: hsl(0, 0%, 100%, 0.84);
+$color-white-transparent-10: hsl(0, 0%, 100%, 0.92);
 
 // Gray
 
-$color-gray-005: hsl(0, 0%, 16%);
-$color-gray-025: hsl(0, 0%, 22%);
-$color-gray-050: hsl(0, 0%, 28%);
-$color-gray-250: hsl(0, 0%, 56%);
-$color-gray-700: hsl(0, 0%, 86%);
-$color-gray-800: hsl(0, 0%, 92%);
-$color-gray-900: hsl(0, 0%, 96%);
+$color-gray-90: hsl(0, 0%, 16%);
+$color-gray-85: hsl(0, 0%, 22%);
+$color-gray-80: hsl(0, 0%, 28%);
+$color-gray-50: hsl(0, 0%, 56%);
+$color-gray-15: hsl(0, 0%, 86%);
+$color-gray-10: hsl(0, 0%, 92%);
+$color-gray-5: hsl(0, 0%, 96%);
 
 // Black
 
-$color-black-transparent-700: hsl(0, 0%, 0%, 0.72);
+$color-black-transparent-70: hsl(0, 0%, 0%, 0.72);
 
 // Red
 
-$color-red-050: hsl(12, 100%, 28%);
-$color-red-075: hsl(12, 100%, 32%);
-$color-red-100: hsl(12, 100%, 36%);
-$color-red-250: hsl(12, 56%, 58%);
-$color-red-800: hsl(12, 52%, 92%);
-$color-red-900: hsl(12, 52%, 96%);
+$color-red-80: hsl(12, 100%, 28%);
+$color-red-75: hsl(12, 100%, 32%);
+$color-red-70: hsl(12, 100%, 36%);
+$color-red-50: hsl(12, 56%, 58%);
+$color-red-10: hsl(12, 52%, 92%);
+$color-red-5: hsl(12, 52%, 96%);
 
 // Yellow
 
-$color-yellow-050: hsl(44, 100%, 18%);
-$color-yellow-075: hsl(44, 100%, 22%);
-$color-yellow-100: hsl(44, 100%, 24%);
-$color-yellow-250: hsl(44, 56%, 42%);
-$color-yellow-800: hsl(44, 80%, 86%);
-$color-yellow-900: hsl(44, 80%, 94%);
+$color-yellow-80: hsl(44, 100%, 18%);
+$color-yellow-75: hsl(44, 100%, 22%);
+$color-yellow-70: hsl(44, 100%, 24%);
+$color-yellow-50: hsl(44, 56%, 42%);
+$color-yellow-10: hsl(44, 80%, 86%);
+$color-yellow-5: hsl(44, 80%, 94%);
 
 // Green
 
-$color-green-050: hsl(138, 100%, 16%);
-$color-green-075: hsl(138, 100%, 20%);
-$color-green-100: hsl(138, 100%, 22%);
-$color-green-250: hsl(138, 56%, 40%);
-$color-green-800: hsl(138, 76%, 86%);
-$color-green-900: hsl(138, 76%, 94%);
+$color-green-80: hsl(138, 100%, 16%);
+$color-green-75: hsl(138, 100%, 20%);
+$color-green-70: hsl(138, 100%, 22%);
+$color-green-50: hsl(138, 56%, 40%);
+$color-green-10: hsl(138, 76%, 86%);
+$color-green-5: hsl(138, 76%, 94%);
 
 // Blue
 
-$color-blue-050: hsl(208, 100%, 28%);
-$color-blue-075: hsl(208, 100%, 32%);
-$color-blue-100: hsl(208, 100%, 36%);
-$color-blue-250: hsl(208, 76%, 54%);
-$color-blue-800: hsl(208, 92%, 92%);
-$color-blue-900: hsl(208, 92%, 96%);
+$color-blue-80: hsl(208, 100%, 28%);
+$color-blue-75: hsl(208, 100%, 32%);
+$color-blue-70: hsl(208, 100%, 36%);
+$color-blue-50: hsl(208, 76%, 54%);
+$color-blue-10: hsl(208, 92%, 92%);
+$color-blue-5: hsl(208, 92%, 96%);
 
 // Transparent
 

--- a/source/tokens/reference/color.scss
+++ b/source/tokens/reference/color.scss
@@ -4,20 +4,20 @@
 // White
 
 $color-white: hsl(0, 0%, 100%);
-$color-white-transparent-90: hsl(0, 0%, 100%, 0.08);
-$color-white-transparent-80: hsl(0, 0%, 100%, 0.16);
-$color-white-transparent-20: hsl(0, 0%, 100%, 0.84);
 $color-white-transparent-10: hsl(0, 0%, 100%, 0.92);
+$color-white-transparent-20: hsl(0, 0%, 100%, 0.84);
+$color-white-transparent-80: hsl(0, 0%, 100%, 0.16);
+$color-white-transparent-90: hsl(0, 0%, 100%, 0.08);
 
 // Gray
 
-$color-gray-90: hsl(0, 0%, 16%);
-$color-gray-85: hsl(0, 0%, 22%);
-$color-gray-80: hsl(0, 0%, 28%);
-$color-gray-50: hsl(0, 0%, 56%);
-$color-gray-15: hsl(0, 0%, 86%);
-$color-gray-10: hsl(0, 0%, 92%);
 $color-gray-5: hsl(0, 0%, 96%);
+$color-gray-10: hsl(0, 0%, 92%);
+$color-gray-15: hsl(0, 0%, 86%);
+$color-gray-50: hsl(0, 0%, 56%);
+$color-gray-80: hsl(0, 0%, 28%);
+$color-gray-85: hsl(0, 0%, 22%);
+$color-gray-90: hsl(0, 0%, 16%);
 
 // Black
 
@@ -25,39 +25,39 @@ $color-black-transparent-70: hsl(0, 0%, 0%, 0.72);
 
 // Red
 
-$color-red-80: hsl(12, 100%, 28%);
-$color-red-75: hsl(12, 100%, 32%);
-$color-red-70: hsl(12, 100%, 36%);
-$color-red-50: hsl(12, 56%, 58%);
-$color-red-10: hsl(12, 52%, 92%);
 $color-red-5: hsl(12, 52%, 96%);
+$color-red-10: hsl(12, 52%, 92%);
+$color-red-50: hsl(12, 56%, 58%);
+$color-red-70: hsl(12, 100%, 36%);
+$color-red-75: hsl(12, 100%, 32%);
+$color-red-80: hsl(12, 100%, 28%);
 
 // Yellow
 
-$color-yellow-80: hsl(44, 100%, 18%);
-$color-yellow-75: hsl(44, 100%, 22%);
-$color-yellow-70: hsl(44, 100%, 24%);
-$color-yellow-50: hsl(44, 56%, 42%);
-$color-yellow-10: hsl(44, 80%, 86%);
 $color-yellow-5: hsl(44, 80%, 94%);
+$color-yellow-10: hsl(44, 80%, 86%);
+$color-yellow-50: hsl(44, 56%, 42%);
+$color-yellow-70: hsl(44, 100%, 24%);
+$color-yellow-75: hsl(44, 100%, 22%);
+$color-yellow-80: hsl(44, 100%, 18%);
 
 // Green
 
-$color-green-80: hsl(138, 100%, 16%);
-$color-green-75: hsl(138, 100%, 20%);
-$color-green-70: hsl(138, 100%, 22%);
-$color-green-50: hsl(138, 56%, 40%);
-$color-green-10: hsl(138, 76%, 86%);
 $color-green-5: hsl(138, 76%, 94%);
+$color-green-10: hsl(138, 76%, 86%);
+$color-green-50: hsl(138, 56%, 40%);
+$color-green-70: hsl(138, 100%, 22%);
+$color-green-75: hsl(138, 100%, 20%);
+$color-green-80: hsl(138, 100%, 16%);
 
 // Blue
 
-$color-blue-80: hsl(208, 100%, 28%);
-$color-blue-75: hsl(208, 100%, 32%);
-$color-blue-70: hsl(208, 100%, 36%);
-$color-blue-50: hsl(208, 76%, 54%);
-$color-blue-10: hsl(208, 92%, 92%);
 $color-blue-5: hsl(208, 92%, 96%);
+$color-blue-10: hsl(208, 92%, 92%);
+$color-blue-50: hsl(208, 76%, 54%);
+$color-blue-70: hsl(208, 100%, 36%);
+$color-blue-75: hsl(208, 100%, 32%);
+$color-blue-80: hsl(208, 100%, 28%);
 
 // Transparent
 


### PR DESCRIPTION
Previous color grades were closely related to computed luminance values. This approach is unnecessarily complex and requires scrutiny for each value update. Instead, use numbers that represent the lightness or darkness of a color: the higher the number, the darker the color. Luminance measurements should still be employed, but only as a means of ensuring colors are perceptually similar.