### PR TITLE
Change transparent black grade

### DIFF
--- a/source/tokens/color.scss
+++ b/source/tokens/color.scss
@@ -86,7 +86,7 @@ $color-background-inverse-transparent-hover: $color-white-transparent-90;
 $color-background-inverse-transparent-active: $color-white-transparent-80;
 
 $color-background-transparent: $color-transparent;
-$color-background-transparent-dim: $color-black-transparent-70;
+$color-background-transparent-dim: $color-black-transparent-30;
 
 $color-background-selected: $color-blue-70;
 

--- a/source/tokens/reference/color.scss
+++ b/source/tokens/reference/color.scss
@@ -21,7 +21,7 @@ $color-gray-90: hsl(0, 0%, 16%);
 
 // Black
 
-$color-black-transparent-70: hsl(0, 0%, 0%, 0.72);
+$color-black-transparent-30: hsl(0, 0%, 0%, 0.72);
 
 // Red
 


### PR DESCRIPTION
Use lower grades to establish higher opacity values in order to match the naming convention used to define plain colors.