### PR TITLE
Rename regular color tokens

### DIFF
--- a/source/components/accordion/accordion.scss
+++ b/source/components/accordion/accordion.scss
@@ -7,10 +7,10 @@
 
 .accordion {
   &-segment {
-    border-top: $border-width-regular solid $color-border-regular-subtle;
+    border-top: $border-width-regular solid $color-border-neutral-subtle;
 
     &:last-child {
-      border-bottom: $border-width-regular solid $color-border-regular-subtle;
+      border-bottom: $border-width-regular solid $color-border-neutral-subtle;
     }
   }
 
@@ -23,7 +23,7 @@
     margin-top: -$border-width-regular;
     font-size: $font-size-large-a;
     line-height: $line-height-small-c;
-    color: $color-text-regular;
+    color: $color-text-neutral;
     background-color: $color-background-transparent;
     transition: color $ease-out-100, outline $ease-out-100;
 
@@ -36,7 +36,7 @@
     }
 
     &:hover {
-      color: $color-text-regular-divergent-hover;
+      color: $color-text-neutral-divergent-hover;
     }
   }
 

--- a/source/components/breadcrumb/breadcrumb.scss
+++ b/source/components/breadcrumb/breadcrumb.scss
@@ -13,7 +13,7 @@
 
   &-link {
     display: inline-block;
-    color: $color-text-regular;
+    color: $color-text-neutral;
     text-decoration: $border-width-regular underline currentColor;
     text-underline-offset: 0.25rem;
     transition: text-decoration $ease-out-100, outline $ease-out-100;

--- a/source/components/card/card-variants.scss
+++ b/source/components/card/card-variants.scss
@@ -18,15 +18,15 @@
   transition: background-color $ease-out-100, outline $ease-out-100;
 
   &:hover {
-    background-color: $color-background-regular-hover;
+    background-color: $color-background-neutral-hover;
   }
 
   &:active {
-    background-color: $color-background-regular-active;
+    background-color: $color-background-neutral-active;
   }
 
   .card-link {
-    color: $color-text-regular;
+    color: $color-text-neutral;
 
     &:focus-visible {
       outline: 0;

--- a/source/components/card/card.scss
+++ b/source/components/card/card.scss
@@ -10,10 +10,10 @@
   flex-direction: column;
   gap: $space-regular;
   padding: calc(#{$space-large-b} - #{$border-width-regular});
-  border: $border-width-regular solid $color-border-regular-subtle;
+  border: $border-width-regular solid $color-border-neutral-subtle;
   border-radius: $border-radius-regular;
-  color: $color-text-regular;
-  background-color: $color-background-regular;
+  color: $color-text-neutral;
+  background-color: $color-background-neutral;
 
   &-cover {
     max-width: calc(100% + 2 * #{$space-large-b});

--- a/source/components/checkbox/checkbox.scss
+++ b/source/components/checkbox/checkbox.scss
@@ -7,10 +7,10 @@
 .checkbox {
   width: 1.5rem;
   height: 1.5rem;
-  border: $border-width-regular solid $color-border-regular;
+  border: $border-width-regular solid $color-border-neutral;
   border-radius: $border-radius-regular;
   vertical-align: middle;
-  background-color: $color-background-regular;
+  background-color: $color-background-neutral;
   cursor: pointer;
   appearance: none;
   transition: border-color $ease-out-100, background-color $ease-out-100, outline $ease-out-100;

--- a/source/components/dialog/dialog.scss
+++ b/source/components/dialog/dialog.scss
@@ -14,8 +14,8 @@
   padding: $space-large-b;
   border-radius: $border-radius-regular;
   margin: $space-large-b;
-  color: $color-text-regular;
-  background-color: $color-background-regular;
+  color: $color-text-neutral;
+  background-color: $color-background-neutral;
 
   &:focus-visible {
     outline: 0;

--- a/source/components/global-footer/global-footer.scss
+++ b/source/components/global-footer/global-footer.scss
@@ -37,7 +37,7 @@
 
   &-link {
     display: inline-block;
-    color: $color-text-regular;
+    color: $color-text-neutral;
     transition: color $ease-out-100, outline $ease-out-100;
 
     &:focus-visible {
@@ -45,7 +45,7 @@
     }
 
     &:hover {
-      color: $color-text-regular-divergent-hover;
+      color: $color-text-neutral-divergent-hover;
     }
   }
 

--- a/source/components/global-header/global-header.scss
+++ b/source/components/global-header/global-header.scss
@@ -28,7 +28,7 @@
     font-size: $font-size-large-c;
     line-height: $line-height-small-c;
     font-weight: $font-weight-bold-b;
-    color: $color-text-regular;
+    color: $color-text-neutral;
     transition: color $ease-out-100, outline $ease-out-100;
 
     &:focus-visible {
@@ -36,7 +36,7 @@
     }
 
     &:hover {
-      color: $color-text-regular-divergent-hover;
+      color: $color-text-neutral-divergent-hover;
     }
   }
 
@@ -57,7 +57,7 @@
       display: inline-block;
       padding-top: $space-small-d;
       padding-bottom: $space-small-d;
-      color: $color-text-regular;
+      color: $color-text-neutral;
       transition: color $ease-out-100, outline $ease-out-100;
 
       &:focus-visible {
@@ -65,13 +65,13 @@
       }
 
       &:hover {
-        color: $color-text-regular-divergent-hover;
+        color: $color-text-neutral-divergent-hover;
       }
 
       &.activated {
         padding-bottom: calc(#{$space-small-d} - #{$border-width-thick-a});
         border-bottom: $border-width-thick-a solid $color-border-activated;
-        color: $color-text-regular-divergent-hover;
+        color: $color-text-neutral-divergent-hover;
       }
     }
   }

--- a/source/components/menu/menu.scss
+++ b/source/components/menu/menu.scss
@@ -11,11 +11,11 @@
   display: none;
   flex-direction: column;
   padding: calc(#{$space-small-c} - #{$border-width-regular});
-  border: $border-width-regular solid $color-border-regular-subtle;
+  border: $border-width-regular solid $color-border-neutral-subtle;
   border-radius: $border-radius-regular;
   margin-top: $space-small-a;
   list-style: none;
-  background-color: $color-background-regular;
+  background-color: $color-background-neutral;
 
   &.shown {
     display: flex;
@@ -28,7 +28,7 @@
     font-size: $font-size-regular;
     line-height: $line-height-regular;
     white-space: nowrap;
-    color: $color-text-regular;
+    color: $color-text-neutral;
     transition: color $ease-out-100, background-color $ease-out-100, outline $ease-out-100;
 
     &:focus-visible {
@@ -36,11 +36,11 @@
     }
 
     &:hover {
-      background-color: $color-background-regular-hover;
+      background-color: $color-background-neutral-hover;
     }
 
     &:active {
-      background-color: $color-background-regular-active;
+      background-color: $color-background-neutral-active;
     }
   }
 

--- a/source/components/navigation/navigation.scss
+++ b/source/components/navigation/navigation.scss
@@ -18,7 +18,7 @@
     padding-bottom: $space-small-a;
     font-size: $font-size-regular;
     line-height: $line-height-regular;
-    color: $color-text-regular;
+    color: $color-text-neutral;
     transition: color $ease-out-100, outline $ease-out-100;
 
     &:focus-visible {

--- a/source/components/radio/radio.scss
+++ b/source/components/radio/radio.scss
@@ -7,10 +7,10 @@
 .radio {
   width: 1.5rem;
   height: 1.5rem;
-  border: $border-width-regular solid $color-border-regular;
+  border: $border-width-regular solid $color-border-neutral;
   border-radius: $border-radius-full;
   vertical-align: middle;
-  background-color: $color-background-regular;
+  background-color: $color-background-neutral;
   cursor: pointer;
   appearance: none;
   transition: border-color $ease-out-100, background-color $ease-out-100, outline $ease-out-100;

--- a/source/components/switch/switch.scss
+++ b/source/components/switch/switch.scss
@@ -7,14 +7,14 @@
 .switch {
   width: 2.5rem;
   height: 1.5rem;
-  border: $border-width-regular solid $color-text-regular;
+  border: $border-width-regular solid $color-text-neutral;
   border-radius: $border-radius-full;
   vertical-align: middle;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><circle cx='8' cy='8' r='5' fill='%233d3d3d'/></svg>");
   background-position: left center;
   background-size: 1.5rem;
   background-repeat: no-repeat;
-  background-color: $color-background-regular;
+  background-color: $color-background-neutral;
   cursor: pointer;
   appearance: none;
   transition: border-color $ease-out-100, background-position $ease-out-100, background-color $ease-out-100, outline $ease-out-100;

--- a/source/components/table/table.scss
+++ b/source/components/table/table.scss
@@ -15,7 +15,7 @@
   &-header,
   &-data {
     padding: $space-small-e $space-regular calc(#{$space-small-e} - #{$border-width-regular});
-    border-bottom: $border-width-regular solid $color-border-regular-subtle;
+    border-bottom: $border-width-regular solid $color-border-neutral-subtle;
     vertical-align: top;
   }
 
@@ -23,11 +23,11 @@
     text-align: left;
 
     thead & {
-      border-color: $color-border-regular;
+      border-color: $color-border-neutral;
     }
 
     tbody & {
-      border-right: $border-width-regular solid $color-border-regular;
+      border-right: $border-width-regular solid $color-border-neutral;
     }
   }
 }

--- a/source/components/tabset/tabset.scss
+++ b/source/components/tabset/tabset.scss
@@ -10,7 +10,7 @@
   &-navigation {
     display: flex;
     padding-left: 0;
-    border-bottom: $border-width-regular solid $color-border-regular-subtle;
+    border-bottom: $border-width-regular solid $color-border-neutral-subtle;
     margin-bottom: 0;
     list-style: none;
   }
@@ -22,7 +22,7 @@
     padding: $space-small-d $space-regular;
     border: 0;
     margin-bottom: -#{$border-width-regular};
-    color: $color-text-regular;
+    color: $color-text-neutral;
     background-color: $color-background-transparent;
     transition: border-color $ease-out-100, color $ease-out-100, outline $ease-out-100;
 
@@ -31,7 +31,7 @@
     }
 
     &:hover {
-      color: $color-text-regular-divergent-hover;
+      color: $color-text-neutral-divergent-hover;
     }
 
     &.activated {

--- a/source/components/textfield/textfield.scss
+++ b/source/components/textfield/textfield.scss
@@ -8,12 +8,12 @@
   display: block;
   width: 100%;
   padding: calc(#{$space-small-d} - #{$border-width-regular}) calc(#{$space-small-e} - #{$border-width-regular});
-  border: $border-width-regular solid $color-border-regular;
+  border: $border-width-regular solid $color-border-neutral;
   border-radius: $border-radius-regular;
   font-size: $font-size-regular;
   line-height: $line-height-regular;
-  color: $color-text-regular;
-  background-color: $color-background-regular;
+  color: $color-text-neutral;
+  background-color: $color-background-neutral;
   transition: outline $ease-out-100, border-color $ease-out-100;
 
   &:focus-visible {

--- a/source/reset.scss
+++ b/source/reset.scss
@@ -32,9 +32,9 @@ body {
   font-size: $font-size-regular;
   line-height: $line-height-regular;
   font-weight: $font-weight-regular;
-  color: $color-text-regular;
+  color: $color-text-neutral;
   overflow-wrap: break-word;
-  background-color: $color-background-regular;
+  background-color: $color-background-neutral;
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -137,7 +137,7 @@ video[controls] {
 hr {
   overflow: visible;
   border: 0;
-  border-top: $border-width-thick-b solid $color-border-regular-subtle;
+  border-top: $border-width-thick-b solid $color-border-neutral-subtle;
 }
 
 // Anchor

--- a/source/tokens/color.scss
+++ b/source/tokens/color.scss
@@ -5,8 +5,8 @@
 
 // Text
 
-$color-text-regular: $color-gray-800;
-$color-text-regular-divergent-hover: $color-blue-700;
+$color-text-neutral: $color-gray-800;
+$color-text-neutral-divergent-hover: $color-blue-700;
 
 $color-text-primary: $color-blue-700;
 $color-text-secondary: $color-gray-800;
@@ -23,8 +23,8 @@ $color-text-disabled: $color-black-transparent-600;
 
 // Border
 
-$color-border-regular: $color-gray-500;
-$color-border-regular-subtle: $color-gray-150;
+$color-border-neutral: $color-gray-500;
+$color-border-neutral-subtle: $color-gray-150;
 
 $color-border-primary: $color-blue-400;
 $color-border-secondary: $color-gray-500;
@@ -42,9 +42,9 @@ $color-border-selected: $color-blue-700;
 
 // Background
 
-$color-background-regular: $color-white;
-$color-background-regular-hover: $color-gray-50;
-$color-background-regular-active: $color-gray-100;
+$color-background-neutral: $color-white;
+$color-background-neutral-hover: $color-gray-50;
+$color-background-neutral-active: $color-gray-100;
 
 $color-background-primary: $color-blue-700;
 $color-background-primary-hover: $color-blue-750;


### PR DESCRIPTION
Employ the term "neutral" to designate text, border, and background tokens used to style default items that have no strongly marked characteristics or features. As opposed to "regular" it does not imply a level of standardization or conformity thus allowing even limited usage.