### PR TITLE
Add icon color tokens

### DIFF
--- a/source/tokens/color.scss
+++ b/source/tokens/color.scss
@@ -20,6 +20,23 @@ $color-text-inverse-disabled: $color-white-transparent-600;
 $color-text-activated: $color-blue-700;
 $color-text-disabled: $color-black-transparent-600;
 
+// Icon
+
+$color-icon-neutral: $color-gray-800;
+$color-icon-neutral-divergent-hover: $color-blue-700;
+
+$color-icon-primary: $color-blue-700;
+
+$color-icon-positive: $color-green-700;
+$color-icon-attentive: $color-yellow-700;
+$color-icon-negative: $color-red-700;
+
+$color-icon-inverse: $color-white;
+$color-icon-inverse-disabled: $color-white-transparent-600;
+
+$color-icon-activated: $color-blue-700;
+$color-icon-disabled: $color-black-transparent-600;
+
 // Border
 
 $color-border-neutral: $color-gray-500;


### PR DESCRIPTION
Style text and icons using separate tokens as they may employ different colors. Also, since SVG defining attributes, such as fill or stroke, can have different styles, providing dedicated token variants may be useful.